### PR TITLE
Terraform 0.13.x compatibility

### DIFF
--- a/bom/setup-linux.sh
+++ b/bom/setup-linux.sh
@@ -21,7 +21,7 @@ HELMFILE_VERSION=0.125.7
 curl -Lo ./helmfile https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_linux_amd64
 sudo mv helmfile /usr/local/bin
 
-TERRAFORM_VERSION=0.12.28
+TERRAFORM_VERSION=0.13.4
 wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
@@ -68,7 +68,7 @@ curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/
 TF_K14S_PLUGIN_VERSION=0.6.0 && \
 mkdir -p ~/.terraform.d/plugins && \
 curl -LO "https://github.com/k14s/terraform-provider-k14s/releases/download/v${TF_K14S_PLUGIN_VERSION}/terraform-provider-k14s-binaries.tgz" && \
-tar xzvf terraform-provider-k14s-binaries.tgz -C ~/.terraform.d/plugins/ && \
+tar xzvf terraform-provider-k14s-binaries.tgz -C ~/.terraform.d/plugins/registry.terraform.io/hashicorp/k14s/$TF_K14S_PLUGIN_VERSION && \
 rm -Rf terraform-provider-k14s-binaries.tgz
 
 ALIYUN_VERSION=3.0.56 && \

--- a/bom/setup-macos.sh
+++ b/bom/setup-macos.sh
@@ -32,7 +32,7 @@ brew install minio/stable/mc
 TF_K14S_PLUGIN_VERSION=0.6.0 && \
 mkdir -p ~/.terraform.d/plugins && \
 curl -LO "https://github.com/k14s/terraform-provider-k14s/releases/download/v${TF_K14S_PLUGIN_VERSION}/terraform-provider-k14s-binaries.tgz" && \
-tar xzvf terraform-provider-k14s-binaries.tgz -C ~/.terraform.d/plugins/
+tar xzvf terraform-provider-k14s-binaries.tgz -C ~/.terraform.d/plugins/registry.terraform.io/hashicorp/k14s/$TF_K14S_PLUGIN_VERSION
 rm -Rf terraform-provider-k14s-binaries.tgz
 
 TMC_VERSION=0.1.0-829a6124 && \

--- a/bom/setup-windows.ps1
+++ b/bom/setup-windows.ps1
@@ -130,7 +130,7 @@ choco install -y tektoncd-cli
 Set-Variable TF_K14S_PLUGIN_VERSION 0.6.0
 md $HOME/.terraform.d/plugins -ea 0
 curl -LO "https://github.com/k14s/terraform-provider-k14s/releases/download/v$TF_K14S_PLUGIN_VERSION/terraform-provider-k14s-binaries.tgz"
-tar xzvf terraform-provider-k14s-binaries.tgz -C $HOME/.terraform.d/plugins/
+tar xzvf terraform-provider-k14s-binaries.tgz -C $HOME/.terraform.d/plugins/registry.terraform.io/hashicorp/k14s/$TF_K14S_PLUGIN_VERSION
 Remove-Item terraform-provider-k14s-binaries.tgz
 
 

--- a/experiments/amazon/blobstore/blobstore.tf
+++ b/experiments/amazon/blobstore/blobstore.tf
@@ -30,5 +30,5 @@ output "s3_bucket_hosted_zone_id" {
 }
 
 provider "aws" {
-  version = "~> 2.54.0"
+  version = ">= 3.9.0"
 }

--- a/experiments/amazon/blobstore/versions.tf
+++ b/experiments/amazon/blobstore/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/experiments/amazon/iam/iam.tf
+++ b/experiments/amazon/iam/iam.tf
@@ -104,10 +104,6 @@ output "this_iam_user_unique_id" {
 }
 
 provider "aws" {
-  version = "~> 3.9.0"
+  version = ">= 3.9.0"
   region  = var.region
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/experiments/amazon/iam/versions.tf
+++ b/experiments/amazon/iam/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/experiments/gcp/blobstore/versions.tf
+++ b/experiments/gcp/blobstore/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/acme/aws/main.tf
+++ b/modules/acme/aws/main.tf
@@ -1,9 +1,3 @@
-provider "acme" {
-  server_url = "https://acme-v02.api.letsencrypt.org/directory"
-
-  version = "~> 1.5.0"
-}
-
 resource "tls_private_key" "private_key" {
   algorithm = "RSA"
 }

--- a/modules/acme/aws/providers.tf
+++ b/modules/acme/aws/providers.tf
@@ -1,0 +1,5 @@
+provider "acme" {
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+
+  version = "~> 1.5.0"
+}

--- a/modules/acme/aws/versions.tf
+++ b/modules/acme/aws/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    acme = {
+      source = "terraform-providers/acme"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/acme/azure/main.tf
+++ b/modules/acme/azure/main.tf
@@ -1,9 +1,3 @@
-provider "acme" {
-  server_url = "https://acme-v02.api.letsencrypt.org/directory"
-
-  version = "~> 1.5.0"
-}
-
 resource "tls_private_key" "private_key" {
   algorithm = "RSA"
 }

--- a/modules/acme/azure/providers.tf
+++ b/modules/acme/azure/providers.tf
@@ -1,0 +1,5 @@
+provider "acme" {
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+
+  version = "~> 1.5.0"
+}

--- a/modules/acme/azure/versions.tf
+++ b/modules/acme/azure/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    acme = {
+      source = "terraform-providers/acme"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/acme/gcp/main.tf
+++ b/modules/acme/gcp/main.tf
@@ -1,9 +1,3 @@
-provider "acme" {
-  server_url = "https://acme-v02.api.letsencrypt.org/directory"
-
-  version = "~> 1.5.0"
-}
-
 resource "tls_private_key" "private_key" {
   algorithm = "RSA"
 }

--- a/modules/acme/gcp/providers.tf
+++ b/modules/acme/gcp/providers.tf
@@ -1,0 +1,5 @@
+provider "acme" {
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+
+  version = "~> 1.5.0"
+}

--- a/modules/acme/gcp/versions.tf
+++ b/modules/acme/gcp/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    acme = {
+      source = "terraform-providers/acme"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/argo-cd/providers.tf
+++ b/modules/argo-cd/providers.tf
@@ -6,9 +6,5 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
-}
-
-terraform {
-  required_version = "~> 0.12"
+  version = ">= 1.3.1"
 }

--- a/modules/argo-cd/versions.tf
+++ b/modules/argo-cd/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/blobstore/azure/providers.tf
+++ b/modules/blobstore/azure/providers.tf
@@ -6,7 +6,3 @@ provider "azurerm" {
   client_secret = var.az_client_secret
   features {}
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/blobstore/azure/versions.tf
+++ b/modules/blobstore/azure/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/certmanager/amazon/providers.tf
+++ b/modules/certmanager/amazon/providers.tf
@@ -6,15 +6,11 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
   kapp {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/certmanager/amazon/versions.tf
+++ b/modules/certmanager/amazon/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/certmanager/azure/providers.tf
+++ b/modules/certmanager/azure/providers.tf
@@ -6,15 +6,11 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
   kapp {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/certmanager/azure/versions.tf
+++ b/modules/certmanager/azure/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/certmanager/gcp/providers.tf
+++ b/modules/certmanager/gcp/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
@@ -15,6 +15,3 @@ provider "k14s" {
   }
 }
 
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/certmanager/gcp/versions.tf
+++ b/modules/certmanager/gcp/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/cf4k8s/providers.tf
+++ b/modules/cf4k8s/providers.tf
@@ -6,15 +6,11 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
   kapp {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/cf4k8s/versions.tf
+++ b/modules/cf4k8s/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/cluster/aks/providers.tf
+++ b/modules/cluster/aks/providers.tf
@@ -6,7 +6,3 @@ provider "azurerm" {
   client_secret = var.az_client_secret
   features {}
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/cluster/aks/versions.tf
+++ b/modules/cluster/aks/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    http = {
+      source = "hashicorp/http"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/cluster/eks/providers.tf
+++ b/modules/cluster/eks/providers.tf
@@ -1,9 +1,5 @@
 provider "aws" {
   region = var.region
 
-  version = "~> 2.54.0"
-}
-
-terraform {
-  required_version = "~> 0.12"
+  version = ">= 3.9.0"
 }

--- a/modules/cluster/eks/versions.tf
+++ b/modules/cluster/eks/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/cluster/gke/providers.tf
+++ b/modules/cluster/gke/providers.tf
@@ -12,6 +12,3 @@ provider "google-beta" {
   region      = var.gcp_region
 }
 
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/cluster/gke/versions.tf
+++ b/modules/cluster/gke/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+    http = {
+      source = "hashicorp/http"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/concourse/providers.tf
+++ b/modules/concourse/providers.tf
@@ -6,15 +6,11 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
   kapp {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/concourse/versions.tf
+++ b/modules/concourse/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/contour/providers.tf
+++ b/modules/contour/providers.tf
@@ -4,6 +4,3 @@ provider "k14s" {
   }
 }
 
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/contour/versions.tf
+++ b/modules/contour/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    http = {
+      source = "hashicorp/http"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/database/gcp/generate-certs/providers.tf
+++ b/modules/database/gcp/generate-certs/providers.tf
@@ -4,7 +4,3 @@ provider "google" {
   project     = var.project
   region      = var.region
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/database/gcp/generate-certs/versions.tf
+++ b/modules/database/gcp/generate-certs/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/database/gcp/mysql/providers.tf
+++ b/modules/database/gcp/mysql/providers.tf
@@ -11,7 +11,3 @@ provider "google-beta" {
   project     = var.project
   region      = var.region
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/database/gcp/mysql/versions.tf
+++ b/modules/database/gcp/mysql/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/database/gcp/postgres/providers.tf
+++ b/modules/database/gcp/postgres/providers.tf
@@ -11,7 +11,3 @@ provider "google-beta" {
   project     = var.project
   region      = var.region
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/database/gcp/postgres/versions.tf
+++ b/modules/database/gcp/postgres/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/dns/amazon/providers.tf
+++ b/modules/dns/amazon/providers.tf
@@ -1,8 +1,4 @@
 provider "aws" {
-  version = "~> 3.9.0"
+  version = ">= 3.9.0"
   region  = var.region
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/dns/amazon/versions.tf
+++ b/modules/dns/amazon/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/dns/azure/providers.tf
+++ b/modules/dns/azure/providers.tf
@@ -6,7 +6,3 @@ provider "azurerm" {
   tenant_id = var.az_tenant_id
   features {}
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/dns/azure/versions.tf
+++ b/modules/dns/azure/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/dns/gcp/providers.tf
+++ b/modules/dns/gcp/providers.tf
@@ -3,7 +3,3 @@ provider "google" {
   credentials = file(var.gcp_service_account_credentials)
   project     = var.project
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/dns/gcp/versions.tf
+++ b/modules/dns/gcp/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/elasticsearch/providers.tf
+++ b/modules/elasticsearch/providers.tf
@@ -2,9 +2,5 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
-}
-
-terraform {
-  required_version = "~> 0.12"
+  version = ">= 1.3.1"
 }

--- a/modules/elasticsearch/versions.tf
+++ b/modules/elasticsearch/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/external-dns/amazon/providers.tf
+++ b/modules/external-dns/amazon/providers.tf
@@ -6,10 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
-terraform {
-  required_version = "~> 0.12"
-}
 

--- a/modules/external-dns/amazon/versions.tf
+++ b/modules/external-dns/amazon/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/external-dns/azure/providers.tf
+++ b/modules/external-dns/azure/providers.tf
@@ -6,9 +6,6 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/external-dns/azure/versions.tf
+++ b/modules/external-dns/azure/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/external-dns/gcp/providers.tf
+++ b/modules/external-dns/gcp/providers.tf
@@ -6,9 +6,5 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
-}
-
-terraform {
-  required_version = "~> 0.12"
+  version = ">= 1.3.1"
 }

--- a/modules/external-dns/gcp/versions.tf
+++ b/modules/external-dns/gcp/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/flagger/providers.tf
+++ b/modules/flagger/providers.tf
@@ -2,9 +2,5 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
-}
-
-terraform {
-  required_version = "~> 0.12"
+  version = ">= 1.3.1"
 }

--- a/modules/flagger/versions.tf
+++ b/modules/flagger/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/fluentbit/providers.tf
+++ b/modules/fluentbit/providers.tf
@@ -2,9 +2,6 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/fluentbit/versions.tf
+++ b/modules/fluentbit/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/generate-kubeconfig/versions.tf
+++ b/modules/generate-kubeconfig/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/git/gitea/providers.tf
+++ b/modules/git/gitea/providers.tf
@@ -6,15 +6,11 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
   kapp {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/git/gitea/versions.tf
+++ b/modules/git/gitea/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/kibana/providers.tf
+++ b/modules/kibana/providers.tf
@@ -2,7 +2,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
@@ -11,6 +11,3 @@ provider "k14s" {
   }
 }
 
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/kibana/versions.tf
+++ b/modules/kibana/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/kubeapps/providers.tf
+++ b/modules/kubeapps/providers.tf
@@ -2,7 +2,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
@@ -11,6 +11,3 @@ provider "k14s" {
   }
 }
 
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/kubeapps/versions.tf
+++ b/modules/kubeapps/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/loki-stack/providers.tf
+++ b/modules/loki-stack/providers.tf
@@ -6,15 +6,11 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
   kapp {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/loki-stack/versions.tf
+++ b/modules/loki-stack/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/metricbeat/providers.tf
+++ b/modules/metricbeat/providers.tf
@@ -2,9 +2,5 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
-}
-
-terraform {
-  required_version = "~> 0.12"
+  version = ">= 1.3.1"
 }

--- a/modules/metricbeat/versions.tf
+++ b/modules/metricbeat/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/minio/providers.tf
+++ b/modules/minio/providers.tf
@@ -6,9 +6,6 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/minio/versions.tf
+++ b/modules/minio/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/nginx-ingress/providers.tf
+++ b/modules/nginx-ingress/providers.tf
@@ -6,9 +6,5 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
-}
-
-terraform {
-  required_version = "~> 0.12"
+  version = ">= 1.3.1"
 }

--- a/modules/nginx-ingress/versions.tf
+++ b/modules/nginx-ingress/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/pivotal-csb/aws/main.tf
+++ b/modules/pivotal-csb/aws/main.tf
@@ -107,10 +107,14 @@ resource "null_resource" "push_broker" {
 }
 
 resource "null_resource" "register_broker" {
+  triggers {
+    broker_name = "csb-${random_id.suffix.hex}"
+  }
+
   provisioner "local-exec" {
     environment = {
       APP_NAME = "cloud-service-broker"
-      BROKER_NAME = "csb-${random_id.suffix.hex}"
+      BROKER_NAME = self.triggers.broker_name
       SECURITY_USER_NAME = random_uuid.api_user.result
       SECURITY_USER_PASSWORD = random_password.api_password.result
     }
@@ -120,7 +124,7 @@ resource "null_resource" "register_broker" {
   provisioner "local-exec" {
     when = destroy
     environment = {
-      BROKER_NAME = "csb-${random_id.suffix.hex}"
+      BROKER_NAME = self.triggers.broker_name
     }
     command = "cf delete-service-broker $BROKER_NAME -f"
   }

--- a/modules/pivotal-csb/aws/versions.tf
+++ b/modules/pivotal-csb/aws/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/pivotal-csb/azure/main.tf
+++ b/modules/pivotal-csb/azure/main.tf
@@ -105,10 +105,14 @@ resource "null_resource" "push_broker" {
 }
 
 resource "null_resource" "register_broker" {
+  triggers {
+    broker_name = "csb-${random_id.suffix.hex}"
+  }
+  
   provisioner "local-exec" {
     environment = {
       APP_NAME = "cloud-service-broker"
-      BROKER_NAME = "csb-${random_id.suffix.hex}"
+      BROKER_NAME = self.triggers.broker_name
       SECURITY_USER_NAME = random_uuid.api_user.result
       SECURITY_USER_PASSWORD = random_password.api_password.result
     }
@@ -118,7 +122,7 @@ resource "null_resource" "register_broker" {
   provisioner "local-exec" {
     when = destroy
     environment = {
-      BROKER_NAME = "csb-${random_id.suffix.hex}"
+      BROKER_NAME = self.triggers.broker_name
     }
     command = "cf delete-service-broker $BROKER_NAME -f"
   }

--- a/modules/pivotal-csb/azure/versions.tf
+++ b/modules/pivotal-csb/azure/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/pivotal-csb/gcp/main.tf
+++ b/modules/pivotal-csb/gcp/main.tf
@@ -103,10 +103,14 @@ resource "null_resource" "push_broker" {
 }
 
 resource "null_resource" "register_broker" {
+  triggers {
+    broker_name = "csb-${random_id.suffix.hex}"
+  }
+  
   provisioner "local-exec" {
     environment = {
       APP_NAME = "cloud-service-broker"
-      BROKER_NAME = "csb-${random_id.suffix.hex}"
+      BROKER_NAME = self.triggers.broker_name
       SECURITY_USER_NAME = random_uuid.api_user.result
       SECURITY_USER_PASSWORD = random_password.api_password.result
     }
@@ -116,7 +120,7 @@ resource "null_resource" "register_broker" {
   provisioner "local-exec" {
     when = destroy
     environment = {
-      BROKER_NAME = "csb-${random_id.suffix.hex}"
+      BROKER_NAME = self.triggers.broker_name
     }
     command = "cf delete-service-broker $BROKER_NAME -f"
   }

--- a/modules/pivotal-csb/gcp/versions.tf
+++ b/modules/pivotal-csb/gcp/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/registry/acr/providers.tf
+++ b/modules/registry/acr/providers.tf
@@ -6,7 +6,3 @@ provider "azurerm" {
   tenant_id = var.az_tenant_id
   features {}
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/registry/acr/versions.tf
+++ b/modules/registry/acr/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/registry/gcr/providers.tf
+++ b/modules/registry/gcr/providers.tf
@@ -3,7 +3,3 @@ provider "google" {
   credentials = file(var.credentials)
   project     = var.project
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/registry/gcr/versions.tf
+++ b/modules/registry/gcr/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/registry/harbor/providers.tf
+++ b/modules/registry/harbor/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
@@ -15,6 +15,3 @@ provider "k14s" {
   }
 }
 
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/registry/harbor/versions.tf
+++ b/modules/registry/harbor/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/registry/jcr/providers.tf
+++ b/modules/registry/jcr/providers.tf
@@ -6,15 +6,11 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
   kapp {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/registry/jcr/versions.tf
+++ b/modules/registry/jcr/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/sealed-secrets/providers.tf
+++ b/modules/sealed-secrets/providers.tf
@@ -7,7 +7,3 @@ provider "k14s" {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/sealed-secrets/versions.tf
+++ b/modules/sealed-secrets/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/stratos/providers.tf
+++ b/modules/stratos/providers.tf
@@ -6,15 +6,11 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
   kapp {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/stratos/versions.tf
+++ b/modules/stratos/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/tas4k8s/main.tf
+++ b/modules/tas4k8s/main.tf
@@ -21,7 +21,7 @@ resource "random_password" "postgres" {
 }
 
 data "local_file" "certs_vars" {
-  filename = "${path.module}/certs.auto.tfvars"
+  filename = var.certificate_variables_file_path
 }
 
 data "template_file" "baseline_values" {

--- a/modules/tas4k8s/main.tf
+++ b/modules/tas4k8s/main.tf
@@ -21,7 +21,7 @@ resource "random_password" "postgres" {
 }
 
 data "local_file" "certs_vars" {
-  filename = var.certificate_variables_file_path
+  filename = var.certificate_variables_file_path != "" ? var.certificate_variables_file_path: "${path.module}/certs.auto.tfvars"
 }
 
 data "template_file" "baseline_values" {

--- a/modules/tas4k8s/providers.tf
+++ b/modules/tas4k8s/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
@@ -15,6 +15,3 @@ provider "k14s" {
   }
 }
 
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/tas4k8s/vars.tf
+++ b/modules/tas4k8s/vars.tf
@@ -1,6 +1,6 @@
 variable "domain" {}
 
-variable "certficate_variables_file_path" {
+variable "certificate_variables_file_path" {
   default = ""
 }
 

--- a/modules/tas4k8s/vars.tf
+++ b/modules/tas4k8s/vars.tf
@@ -1,5 +1,9 @@
 variable "domain" {}
 
+variable "certficate_variables_file_path" {
+  default = "${path.module}/certs.auto.tfvars"
+}
+
 variable "registry_domain" {}
 
 variable "repository_prefix" {}

--- a/modules/tas4k8s/vars.tf
+++ b/modules/tas4k8s/vars.tf
@@ -1,7 +1,7 @@
 variable "domain" {}
 
 variable "certficate_variables_file_path" {
-  default = "${path.module}/certs.auto.tfvars"
+  default = ""
 }
 
 variable "registry_domain" {}

--- a/modules/tas4k8s/versions.tf
+++ b/modules/tas4k8s/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/tekton/providers.tf
+++ b/modules/tekton/providers.tf
@@ -3,7 +3,3 @@ provider "k14s" {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
 }
-
-terraform {
-  required_version = "~> 0.12"
-}

--- a/modules/tekton/versions.tf
+++ b/modules/tekton/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/tsmgr/providers.tf
+++ b/modules/tsmgr/providers.tf
@@ -6,15 +6,11 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
   kapp {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/tsmgr/versions.tf
+++ b/modules/tsmgr/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/wavefront/providers.tf
+++ b/modules/wavefront/providers.tf
@@ -6,15 +6,11 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.3.1"
+  version = ">= 1.3.1"
 }
 
 provider "k14s" {
   kapp {
     kubeconfig_yaml = file(var.kubeconfig_path)
   }
-}
-
-terraform {
-  required_version = "~> 0.12"
 }

--- a/modules/wavefront/versions.tf
+++ b/modules/wavefront/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    k14s = {
+      source = "hashicorp/k14s"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
* All experiments and modules employ Terraform 0.13.4
* BOM install scripts have been updated accordingly
* required_providers and terrafrom_version specified in versions.tf in each module
* Allow certificate_variables_file_path to be overridden